### PR TITLE
fix single mode (without file-loader) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ var html = require("jade-html?single!./file.jade");
 If you want to use this loader with [file-loader](https://github.com/webpack/file-loader) then you should remove the `single` option:
 
 ```javascript
-var html = require("file?name=[name].html!jade-html!./file.jade");
-// => returns file.jade content as html
+require("file?name=[name].html!jade-html!./file.jade");
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -1,22 +1,44 @@
 # jade html loader for webpack
 
+The loader allows you to get HTML back instead of a function reference. I found this useful for templates which render server side.
+
+## Installation
+
+```sh
+npm i jade-html --save-dev
+```
+
+**Note**: npm version 3 won't automatically install [peerDependencies](https://docs.npmjs.com/files/package.json#peerdependencies), so you need to manual install jade:
+
+```sh
+npm i jade --save-dev
+```
+
 ## Usage
 
-``` javascript
-var html = require("jade-html!./file.jade");
+```javascript
+var html = require("jade-html?single!./file.jade");
 // => returns file.jade content as html
 ```
 
-Allows you to get HTML back instead of a function reference. I found this
-useful for templates which render server side.
+If you want to use this loader with [file-loader](https://github.com/webpack/file-loader) then you should remove the `single` option:
+
+```javascript
+var html = require("file?name=[name].html!jade-html!./file.jade");
+// => returns file.jade content as html
+```
+
+## Options
 
 Possible options are (all passed to jade.compile()):
 
-* self   - set the context
+* self   - set the context;
 
-* pretty - boolean, output pretty html or not
+* pretty - boolean, output pretty html or not;
 
-* locals - set locals
+* locals - set locals;
+
+* single - set this option if you want the loader without file-loader.
 
 Don't forget to polyfill `require` if you want to use it in node.
 See [enhanced-require](https://github.com/webpack/enhanced-require) documentation.
@@ -24,4 +46,3 @@ See [enhanced-require](https://github.com/webpack/enhanced-require) documentatio
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The loader allows you to get HTML back instead of a function reference. I found 
 ## Installation
 
 ```sh
-npm i jade-html --save-dev
+npm i jade-html-loader --save-dev
 ```
 
 **Note**: npm version 3 won't automatically install [peerDependencies](https://docs.npmjs.com/files/package.json#peerdependencies), so you need to manual install jade:

--- a/index.js
+++ b/index.js
@@ -2,20 +2,24 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Scott Beck @bline
 */
+
 var loaderUtils = require("loader-utils");
+
 module.exports = function(source) {
-	this.cacheable && this.cacheable(true);
-	var jade = require("jade");
-	var query = loaderUtils.parseQuery(this.query);
-	var req = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
+	this.cacheable && this.cacheable();
+
+	var jade     = require("jade");
+	var query    = loaderUtils.parseQuery(this.query);
+	var req      = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
+
 	var tmplFunc = jade.compile(source, {
-		filename: req,
-		self: query.self,
-		pretty: query.pretty,
-		locals: query.locals,
-		doctype: query.doctype || 'html',
+		filename:     req,
+		self:         query.self,
+		pretty:       query.pretty,
+		locals:       query.locals,
+		doctype:      query.doctype || "html",
 		compileDebug: this.debug || false
 	});
 
 	return tmplFunc(query);
-}
+};

--- a/index.js
+++ b/index.js
@@ -21,5 +21,7 @@ module.exports = function(source) {
 		compileDebug: this.debug || false
 	});
 
-	return tmplFunc(query);
+	var html = tmplFunc(query);
+
+	return query.single ? "module.exports =" + JSON.stringify(html) + ";" : html;
 };

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ var loaderUtils = require("loader-utils");
 module.exports = function(source) {
 	this.cacheable && this.cacheable();
 
-	var jade     = require("jade");
-	var query    = loaderUtils.parseQuery(this.query);
-	var req      = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
+	var jade  = require("jade");
+	var query = loaderUtils.parseQuery(this.query);
+	var req   = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
 
 	var tmplFunc = jade.compile(source, {
 		filename:     req,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jade-html-loader",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "Scott Beck (@bline)"
   },


### PR DESCRIPTION
Now I can't use it without file-loader, because the last loader in chain should returns the correct string or Buffer. If the last loader returns the incorrect string (this string contains whitespace, characters of tags, etc) then webpack throws error with the message about unexpected token.  I added the single option to avoid it.
