### PR TITLE
fix: move jade to dependencies instead of peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
   "description": "jade to html loader module for webpack",
   "dependencies": {
     "enhanced-require": "^0.5.0-beta6",
+    "jade": "^1.11.0",
     "loader-utils": "0.2.x"
-  },
-  "peerDependencies": {
-    "jade": "^1.7.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
NPM 3 no longer automatically installs peerDeps, so it'd be nice if we moved jade to a regular dep.
